### PR TITLE
fix thunk description issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ And a mountain of applications in server-side or client-side.
 
 3. **`thunk`** returns another **`thunk`** function after being called, for chaining operations.
 
-4. **`thunk`** would passing the results into a `callback` function after excuted.
+4. **`thunk`** passes the results into a `callback` function after being excuted.
 
-5. If `callback` returns a new **`thunk`** function, then it would be send to another **`thunk`** to excute,
-or it would be send to another new **`thunk`** function as the value of the computation.
+5. If the return value of `callback` is a **`thunk`** function, then it will be executed first and its result will be send to another **`thunk`** for excution,
+or it will be send to another new **`thunk`** function as the value of the computation.
 
 ## Demo
 


### PR DESCRIPTION
Fix some grammar problems in thunk descriptions.

bullet 4 has an obvious grammar issue that should be fixed.

The problem of bullet 5 is that `it` in the principal clause should refer to `the return value of a callback`, instead of `the callback` itself (as the original description indicates). This is really confusing at first glance.